### PR TITLE
Emphasising headings in Health Info Output

### DIFF
--- a/Project/ML/Diabetes/DiabetesCommunicator.m
+++ b/Project/ML/Diabetes/DiabetesCommunicator.m
@@ -53,13 +53,14 @@ classdef DiabetesCommunicator
 
             for i = 1:7
                 if(unhealthy(i) == 1)
-                    title = '\bf' + upper(string(healthInfo.fullnames(i))) + '\rm' + newline;
-                    meaning = '\bf' + "Meaning" + '\rm' + newline + string(healthInfo.meaning(i)) + newline;
-                    interpretation = '\bf' + "Interpretation" + '\rm' + newline + string(healthInfo.interpretation(i)) + newline;
-                    change = '\bf' + "How to Improve" + '\rm' + newline + string(healthInfo.change(i)) + newline;
-                    sources = '\bf' + "Further Information" + '\rm' + newline + string(healthInfo.sources(i)) + newline;
+                    spacer = "______________________";
+                    title = "=======" + upper(string(healthInfo.fullnames(i))) + "=======" + newline;
+                    meaning = newline + "---" + "MEANING" + newline + string(healthInfo.meaning(i)) + newline;
+                    interpretation = newline + "---" + "INTERPRETATION" + newline + string(healthInfo.interpretation(i)) + newline;
+                    change = newline + "---" + "HOW TO IMPROVE" + newline + string(healthInfo.change(i)) + newline;
+                    sources = newline + "---" + "FURTHER INFORMATION" + newline + string(healthInfo.sources(i)) + newline;
 
-                    currentText = newline + title + newline + meaning + interpretation + change + sources + newline;
+                    currentText = newline + title + newline + meaning + interpretation + change + sources + newline + spacer + newline;
 
                     infoText(textPosition) = currentText;
 
@@ -67,7 +68,11 @@ classdef DiabetesCommunicator
                 end
             end
 
-            %infoText
+            if(textPosition==1)
+                infoText = "All your values are healthy. See a doctor if any of the values change." + newline + "(or you did not input anything, in which case, please stop playing around.)"
+            end
+
+            %infoText = infoText + '\bf Meaning \rm'
             outputArg = infoText;
 
         end 

--- a/Project/ML/Heart Disease/HeartDiseaseCommunicator.m
+++ b/Project/ML/Heart Disease/HeartDiseaseCommunicator.m
@@ -107,18 +107,23 @@ classdef HeartDiseaseCommunicator
 
             for i = 1:24
                 if(unhealthy(i) == 1)
-                    title = '\bf' + upper(string(healthInfo.fullnames(i))) + '\rm' + newline;
-                    meaning = '\bf' + "Meaning" + '\rm' + newline + string(healthInfo.meaning(i)) + newline;
-                    interpretation = '\bf' + "Interpretation" + '\rm' + newline + string(healthInfo.interpretation(i)) + newline;
-                    change = '\bf' + "How to Improve" + '\rm' + newline + string(healthInfo.change(i)) + newline;
-                    sources = '\bf' + "Further Information" + '\rm' + newline + string(healthInfo.sources(i)) + newline;
+                    spacer = "______________________";
+                    title = "=======" + upper(string(healthInfo.fullnames(i))) + "=======" + newline;
+                    meaning = newline + "---" + "MEANING" + newline + string(healthInfo.meaning(i)) + newline;
+                    interpretation = newline + "---" + "INTERPRETATION" + newline + string(healthInfo.interpretation(i)) + newline;
+                    change = newline + "---" + "HOW TO IMPROVE" + newline + string(healthInfo.change(i)) + newline;
+                    sources = newline + "---" + "FURTHER INFORMATION" + newline + string(healthInfo.sources(i)) + newline;
 
-                    currentText = newline + title + newline + meaning + interpretation + change + sources + newline;
+                    currentText = newline + title + newline + meaning + interpretation + change + sources + newline + spacer + newline;
 
                     infoText(textPosition) = currentText;
 
                     textPosition = textPosition + 1;
                 end
+            end
+
+            if(textPosition==1)
+                infoText = "All your values are healthy. See a doctor if any of the values change." + newline + "(or you did not input anything, in which case, please stop playing around.)"
             end
 
             outputArg = infoText;

--- a/Project/ML/Lumpy Skin/LumpySkinCommunicator.m
+++ b/Project/ML/Lumpy Skin/LumpySkinCommunicator.m
@@ -46,13 +46,14 @@ classdef LumpySkinCommunicator
 
             for i = 1:8
                 if(unhealthy(i) == 1)
-                    title = '\bf' + upper(string(healthInfo.fullnames(i))) + '\rm' + newline;
-                    meaning = '\bf' + "Meaning" + '\rm' + newline + string(healthInfo.meaning(i)) + newline;
-                    interpretation = '\bf' + "Interpretation" + '\rm' + newline + string(healthInfo.interpretation(i)) + newline;
-                    change = '\bf' + "How to Improve" + '\rm' + newline + string(healthInfo.change(i)) + newline;
+                    spacer = "______________________";
+                    title = "=======" + upper(string(healthInfo.fullnames(i))) + "=======" + newline;
+                    meaning = newline + "---" + "MEANING" + newline + string(healthInfo.meaning(i)) + newline;
+                    interpretation = newline + "---" + "INTERPRETATION" + newline + string(healthInfo.interpretation(i)) + newline;
+                    change = newline + "---" + "HOW TO IMPROVE" + newline + string(healthInfo.change(i)) + newline;
                     %sources = '\bf' + "Further Information" + '\rm' + newline + string(healthInfo.sources(i)) + newline;
 
-                    currentText = newline + title + newline + meaning + interpretation + change +newline; %+ sources + newline;
+                    currentText = newline + title + newline + meaning + interpretation + change + newline + spacer + newline;
 
                     infoText(textPosition) = currentText;
 
@@ -60,9 +61,13 @@ classdef LumpySkinCommunicator
                 end
             end
 
-            sources = newline + newline + "SOURCES" + newline + "https://www.fli.de/en/news/animal-disease-situation/lumpy-skin-disease/#:~:text=of%2006.09.2016-,Lumpy%20Skin%20Disease%20(%20LSD%20)%20is%20a%20notifiable%20animal%20disease%20of,countries%20and%20ultimately%20to%20Europe" + newline + "http://www.oie.int/fileadmin/Home/eng/Health_standards/tahm/2.04.13_LSD.pdf" + newline + "Coetzer, J.A.W. (2004). Infectious Diseases of Livestock. Cape Town: Oxford University Press. pp. 1268–1276" + newline + "Yeruham, I; Nir, O; Braverman, Y; Davidson, M; Grinstein, H; Haymovitch, M; Zamir, O (22 July 1995). Spread of Lumpy Skin Disease in Israeli Dairy Herds. The Veterinary Record. 137–4 (4): 91–93. doi:10.1136/vr.137.4.91. PMID 8533249. S2CID 23409535." + newline + "Tulman, E. R.; Afonso, C. L.; Lu, Z.; Zsak, L.; Kutish, G. F.; Rock, D. L. (1 August 2001). Genome of Lumpy Skin Disease Virus. Journal of Virology. 75 (15): 7122–7130. doi:10.1128/JVI.75.15.7122-7130.2001. ISSN 0022-538X. PMC 114441. PMID 11435593"
+            sources = newline + newline + "---" + "FURTHER INFORMATION" + newline + "https://www.fli.de/en/news/animal-disease-situation/lumpy-skin-disease/#:~:text=of%2006.09.2016-,Lumpy%20Skin%20Disease%20(%20LSD%20)%20is%20a%20notifiable%20animal%20disease%20of,countries%20and%20ultimately%20to%20Europe" + newline + "http://www.oie.int/fileadmin/Home/eng/Health_standards/tahm/2.04.13_LSD.pdf" + newline + "Coetzer, J.A.W. (2004). Infectious Diseases of Livestock. Cape Town: Oxford University Press. pp. 1268–1276" + newline + "Yeruham, I; Nir, O; Braverman, Y; Davidson, M; Grinstein, H; Haymovitch, M; Zamir, O (22 July 1995). Spread of Lumpy Skin Disease in Israeli Dairy Herds. The Veterinary Record. 137–4 (4): 91–93. doi:10.1136/vr.137.4.91. PMID 8533249. S2CID 23409535." + newline + "Tulman, E. R.; Afonso, C. L.; Lu, Z.; Zsak, L.; Kutish, G. F.; Rock, D. L. (1 August 2001). Genome of Lumpy Skin Disease Virus. Journal of Virology. 75 (15): 7122–7130. doi:10.1128/JVI.75.15.7122-7130.2001. ISSN 0022-538X. PMC 114441. PMID 11435593"
 
             infoText(9) = sources;
+
+            if(textPosition==1)
+                infoText = "All the values lower the risk of lumpy skin disease." + newline + "(or you did not input anything, in which case, please stop playing around.)"
+            end
 
             outputArg = infoText;
 


### PR DESCRIPTION
As far as I could figure out, you can only bold one entire text box, but setting some text to bold does simply not work. I tested some stuff but it didn't do anything.

In the end, I used = and - as well as line breaks to emphasise the headings, like so:
![image](https://github.com/mango-gremlin/Teamprojekt-Diagnosis-System/assets/104830903/7f7583d7-3bfb-438f-be3f-a9d836944bb8)
